### PR TITLE
Subscriptions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Copy documentation from the GraphQL schema to the generated types (including their fields) as normal Rust documentation. Documentation will show up in the generated docs as well as IDEs that support expanding derive macros (which does not include the RLS yet).
+- Implement and test deserializing subscription responses. We also try to provide helpful error messages when a subscription query is not valid (i.e. when it has more than one top-level field).
+
+### Fixed
+
+- The generated `ResponseData` structs did not convert between snake and camel case.
 
 ## [0.1.0] - 2018-07-04
 

--- a/graphql_query_derive/src/constants.rs
+++ b/graphql_query_derive/src/constants.rs
@@ -22,3 +22,9 @@ pub fn typename_field() -> GqlObjectField {
         type_: FieldType::Named(string_type()),
     }
 }
+
+pub const MULTIPLE_SUBSCRIPTION_FIELDS_ERROR: &str = r##"
+Multiple-field queries on the root subscription field are forbidden by the spec.
+
+See: https://github.com/facebook/graphql/blob/master/spec/Section%205%20--%20Validation.md#subscription-operation-definitions
+"##;

--- a/graphql_query_derive/src/lib.rs
+++ b/graphql_query_derive/src/lib.rs
@@ -24,6 +24,7 @@ mod inputs;
 mod interfaces;
 mod introspection_response;
 mod objects;
+mod operations;
 mod query;
 mod scalars;
 mod schema;

--- a/graphql_query_derive/src/operations.rs
+++ b/graphql_query_derive/src/operations.rs
@@ -1,0 +1,21 @@
+use selection::Selection;
+
+pub enum OperationType {
+    Query,
+    Mutation,
+    Subscription,
+}
+
+#[derive(Debug)]
+pub struct Operation {
+    pub name: String,
+    pub selection: Selection,
+}
+
+pub struct Operations(Vec<Operation>);
+
+impl Operations {
+    fn from_document(doc: ::graphql_parser::query::Document) -> Result<Self, ::failure::Error> {
+        unimplemented!()
+    }
+}

--- a/graphql_query_derive/src/query.rs
+++ b/graphql_query_derive/src/query.rs
@@ -9,10 +9,8 @@ use variables::Variable;
 
 /// This holds all the information we need during the code generation phase.
 pub struct QueryContext {
-    pub _subscription_root: Option<Vec<TokenStream>>,
+    pub root: Option<Vec<TokenStream>>,
     pub fragments: BTreeMap<String, GqlFragment>,
-    pub mutation_root: Option<Vec<TokenStream>>,
-    pub query_root: Option<Vec<TokenStream>>,
     pub schema: Schema,
     pub variables: Vec<Variable>,
 }
@@ -21,10 +19,8 @@ impl QueryContext {
     /// Create a QueryContext with the given Schema.
     pub fn new(schema: Schema) -> QueryContext {
         QueryContext {
-            _subscription_root: None,
+            root: None,
             fragments: BTreeMap::new(),
-            mutation_root: None,
-            query_root: None,
             schema,
             variables: Vec::new(),
         }
@@ -72,10 +68,8 @@ impl QueryContext {
     #[cfg(test)]
     pub fn new_empty() -> QueryContext {
         QueryContext {
-            _subscription_root: None,
             fragments: BTreeMap::new(),
-            mutation_root: None,
-            query_root: None,
+            root: None,
             schema: Schema::new(),
             variables: Vec::new(),
         }

--- a/graphql_query_derive/src/schema.rs
+++ b/graphql_query_derive/src/schema.rs
@@ -78,7 +78,7 @@ impl Schema {
         for definition in query.definitions {
             match definition {
                 query::Definition::Operation(query::OperationDefinition::Query(q)) => {
-                    context.query_root = {
+                    context.root = {
                         let definition = context
                             .schema
                             .query_type
@@ -101,7 +101,7 @@ impl Schema {
                     context.register_variables(&q.variable_definitions);
                 }
                 query::Definition::Operation(query::OperationDefinition::Mutation(q)) => {
-                    context.mutation_root = {
+                    context.root = {
                         let definition = context
                             .schema
                             .mutation_type
@@ -124,7 +124,7 @@ impl Schema {
                     context.register_variables(&q.variable_definitions);
                 }
                 query::Definition::Operation(query::OperationDefinition::Subscription(q)) => {
-                    context._subscription_root = {
+                    context.root = {
                         let definition = context
                             .schema
                             .subscription_type
@@ -173,12 +173,7 @@ impl Schema {
             .collect();
         let fragment_definitions = fragment_definitions?;
         let variables_struct = context.expand_variables();
-        let response_data_fields = context
-            .query_root
-            .as_ref()
-            .or_else(|| context.mutation_root.as_ref())
-            .or_else(|| context._subscription_root.as_ref())
-            .expect("no selection defined");
+        let response_data_fields = context.root.as_ref().expect("no selection defined");
 
         let input_object_definitions: Result<Vec<TokenStream>, _> = context
             .schema

--- a/graphql_query_derive/src/schema.rs
+++ b/graphql_query_derive/src/schema.rs
@@ -137,6 +137,13 @@ impl Schema {
                         let prefix = format!("RUST_{}", prefix);
                         let selection = Selection::from(&q.selection_set);
 
+                        if selection.0.len() > 0 {
+                            Err(format_err!(
+                                "{}",
+                                ::constants::MULTIPLE_SUBSCRIPTION_FIELDS_ERROR
+                            ))?
+                        }
+
                         definitions.extend(
                             definition.field_impls_for_selection(&context, &selection, &prefix)?,
                         );

--- a/graphql_query_derive/src/schema.rs
+++ b/graphql_query_derive/src/schema.rs
@@ -137,7 +137,7 @@ impl Schema {
                         let prefix = format!("RUST_{}", prefix);
                         let selection = Selection::from(&q.selection_set);
 
-                        if selection.0.len() > 0 {
+                        if selection.0.len() > 1 {
                             Err(format_err!(
                                 "{}",
                                 ::constants::MULTIPLE_SUBSCRIPTION_FIELDS_ERROR
@@ -216,6 +216,7 @@ impl Schema {
             #variables_struct
 
             #[derive(Debug, Serialize, Deserialize)]
+            #[serde(rename_all = "camelCase")]
             pub struct ResponseData {
                 #(#response_data_fields)*,
             }

--- a/tests/subscription/subscription_invalid_query.graphql
+++ b/tests/subscription/subscription_invalid_query.graphql
@@ -1,0 +1,8 @@
+subscription InvalidSubscription($filter: String) {
+  newDogs {
+    name
+  }
+  dogBirthdays(filter: $filter) {
+    name
+  }
+}

--- a/tests/subscription/subscription_query.graphql
+++ b/tests/subscription/subscription_query.graphql
@@ -1,0 +1,5 @@
+subscription Birthdays($filter: String) {
+  dogBirthdays(filter: $filter) {
+    name
+  }
+}

--- a/tests/subscription/subscription_query_response.json
+++ b/tests/subscription/subscription_query_response.json
@@ -1,0 +1,16 @@
+{
+    "dogBirthdays": [
+        {
+            "name": "Maya"
+        },
+        {
+            "name": "Norbert"
+        },
+        {
+            "name": "Strelka"
+        },
+        {
+            "name": "Belka"
+        }
+    ]
+}

--- a/tests/subscription/subscription_schema.graphql
+++ b/tests/subscription/subscription_schema.graphql
@@ -13,11 +13,12 @@ type SimpleMutation {
 }
 
 type SimpleSubscription {
-  newDogs: Dog
-  dogBirthdays(filter: String): DogBirthday
+  newDogs: [Dog]
+  dogBirthdays(filter: String): [DogBirthday!]
 }
 
 type DogBirthday {
+  name: String
   date: String
   age: Int
   treats: [String]

--- a/tests/subscription/subscription_schema.graphql
+++ b/tests/subscription/subscription_schema.graphql
@@ -1,0 +1,32 @@
+schema {
+  query: SimpleQuery
+  mutation: SimpleMutation
+  subscription: SimpleSubscription
+}
+
+type SimpleQuery {
+  dogByName(name: String): Dog
+}
+
+type SimpleMutation {
+  petDog(dogName: String): Dog
+}
+
+type SimpleSubscription {
+  newDogs: Dog
+  dogBirthdays(filter: String): DogBirthday
+}
+
+type DogBirthday {
+  date: String
+  age: Int
+  treats: [String]
+}
+
+type Dog {
+  name: String!
+  """
+  Always returns true
+  """
+  isGoodDog: Boolean!
+}

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+extern crate graphql_client;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate serde_json;
+
+// If you comment this out, it will not compile because the query is not valid. We need to investigate how we can make this a real test.
+//
+// #[derive(GraphQLQuery)]
+// #[graphql(
+//     schema_path = "tests/subscription/subscription_schema.graphql",
+//     query_path = "tests/subscription/subscription_invalid_query.graphql"
+// )]
+// struct SubscriptionInvalidQuery;
+
+#[test]
+fn subscriptions_work() {
+    unimplemented!("subscriptions test");
+}

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -5,7 +5,9 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
-// If you comment this out, it will not compile because the query is not valid. We need to investigate how we can make this a real test.
+const RESPONSE: &str = include_str!("subscription/subscription_query_response.json");
+
+// If you uncomment this, it will not compile because the query is not valid. We need to investigate how we can make this a real test.
 //
 // #[derive(GraphQLQuery)]
 // #[graphql(
@@ -14,7 +16,23 @@ extern crate serde_json;
 // )]
 // struct SubscriptionInvalidQuery;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "tests/subscription/subscription_schema.graphql",
+    query_path = "tests/subscription/subscription_query.graphql",
+)]
+struct SubscriptionQuery;
+
 #[test]
 fn subscriptions_work() {
-    unimplemented!("subscriptions test");
+    let response_data: subscription_query::ResponseData = serde_json::from_str(RESPONSE).unwrap();
+
+    let expected = r##"ResponseData { dog_birthdays: Some([RustBirthdaysDogBirthdays { name: Some("Maya") }, RustBirthdaysDogBirthdays { name: Some("Norbert") }, RustBirthdaysDogBirthdays { name: Some("Strelka") }, RustBirthdaysDogBirthdays { name: Some("Belka") }]) }"##;
+
+    assert_eq!(format!("{:?}", response_data), expected);
+
+    assert_eq!(
+        response_data.dog_birthdays.map(|birthdays| birthdays.len()),
+        Some(4)
+    );
 }


### PR DESCRIPTION
For now this is mostly about cleaning up how we handle the operations from the query. This paves the way for validating that we only have one field in a subscription (as per the spec) and for selecting an operation for a multi-operation document later.