### PR TITLE
Implement custom deserialization for custom scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Support for multi-operations documents. You can select a particular operation by naming the struct under derive after it.
+- (breaking) Control over which types custom scalars deserialize to is given to the user: you now have to provide type aliases for the custom scalars in the scope of the struct under derive.
+- (breaking) Support for multi-operations documents. You can select a particular operation by naming the struct under derive after it. In case there is no match, we revert to the current behaviour: select the first operation.
 
 ## [0.3.0] - 2018-07-24
 

--- a/examples/example_module/src/custom_scalars.rs
+++ b/examples/example_module/src/custom_scalars.rs
@@ -1,0 +1,10 @@
+//! We define the custom scalars present in the GitHub schema. More precise types could be provided here (see tests), as long as they are deserializable.
+
+pub type X509Certificate = String;
+pub type URI = String;
+pub type HTML = String;
+pub type GitTimestamp = String;
+pub type GitSSHRemote = String;
+pub type GitObjectID = String;
+pub type Date = String;
+pub type DateTime = String;

--- a/examples/example_module/src/lib.rs
+++ b/examples/example_module/src/lib.rs
@@ -4,6 +4,10 @@ extern crate serde_derive;
 #[macro_use]
 extern crate graphql_client;
 
+pub mod custom_scalars;
+
+use custom_scalars::*;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "../github/src/schema.graphql",

--- a/examples/github/src/main.rs
+++ b/examples/github/src/main.rs
@@ -20,6 +20,15 @@ extern crate prettytable;
 use graphql_client::*;
 use structopt::StructOpt;
 
+type X509Certificate = String;
+type URI = String;
+type HTML = String;
+type GitTimestamp = String;
+type GitSSHRemote = String;
+type GitObjectID = String;
+type Date = String;
+type DateTime = String;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/schema.graphql",

--- a/graphql_query_derive/src/operations.rs
+++ b/graphql_query_derive/src/operations.rs
@@ -1,5 +1,4 @@
 use constants::*;
-use graphql_parser;
 use graphql_parser::query::OperationDefinition;
 use heck::SnakeCase;
 use proc_macro2::{Span, TokenStream};

--- a/graphql_query_derive/src/query.rs
+++ b/graphql_query_derive/src/query.rs
@@ -1,9 +1,7 @@
 use failure;
 use fragments::GqlFragment;
-use graphql_parser;
-use heck::SnakeCase;
 use operations::Operation;
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::TokenStream;
 use schema::Schema;
 use selection::Selection;
 use std::collections::BTreeMap;

--- a/graphql_query_derive/src/scalars.rs
+++ b/graphql_query_derive/src/scalars.rs
@@ -15,6 +15,6 @@ impl Scalar {
             Some(d) => quote!(#[doc = #d]),
             None => quote!(),
         };
-        quote!(#description type #ident = String;)
+        quote!(#description type #ident = super::#ident;)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ use std::collections::HashMap;
 ///
 /// Example:
 ///
-///
 /// ```
 /// extern crate failure;
 /// #[macro_use]
@@ -64,7 +63,6 @@ use std::collections::HashMap;
 ///
 ///     Ok(())
 /// }
-/// ```
 /// ```
 pub trait GraphQLQuery<'de> {
     /// The shape of the variables expected by the query. This should be a generated struct most of the time.

--- a/tests/custom_scalars.rs
+++ b/tests/custom_scalars.rs
@@ -1,0 +1,43 @@
+#[macro_use]
+extern crate graphql_client;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
+
+use std::net::Ipv4Addr;
+
+// Important! The NetworkAddress scalar should deserialize to an Ipv4Addr from the Rust std library.
+type NetworkAddress = Ipv4Addr;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "tests/custom_scalars/query.graphql",
+    schema_path = "tests/custom_scalars/schema.graphql"
+)]
+#[allow(dead_code)]
+struct CustomScalarsQuery;
+
+#[test]
+fn custom_scalars() {
+    let valid_response = json!({
+        "address": "127.0.1.2",
+    });
+
+    let valid_addr =
+        serde_json::from_value::<custom_scalars_query::ResponseData>(valid_response).unwrap();
+
+    assert_eq!(
+        valid_addr.address.unwrap(),
+        "127.0.1.2".parse::<Ipv4Addr>().unwrap()
+    );
+
+    let invalid_response = json!({
+        "address": "localhost",
+    });
+
+    assert!(
+        serde_json::from_value::<custom_scalars_query::ResponseData>(invalid_response).is_err()
+    );
+}

--- a/tests/custom_scalars/query.graphql
+++ b/tests/custom_scalars/query.graphql
@@ -1,0 +1,3 @@
+query CustomScalarQuery {
+  address
+}

--- a/tests/custom_scalars/schema.graphql
+++ b/tests/custom_scalars/schema.graphql
@@ -1,0 +1,12 @@
+schema {
+  query: QueryRoot
+}
+
+"""
+An IPv4 address
+"""
+scalar NetworkAddress
+
+type QueryRoot {
+  address: NetworkAddress
+}

--- a/tests/input_object_variables.rs
+++ b/tests/input_object_variables.rs
@@ -27,6 +27,9 @@ fn input_object_variables_query_variables_struct() {
     };
 }
 
+// Custom scalars
+type Email = String;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     query_path = "tests/input_object_variables/input_object_variables_query_defaults.graphql",


### PR DESCRIPTION
Users of the library now have to provide type aliases for the scalars defined in the schema in the parent scope (the scope of the struct under derive).