### PR TITLE
Add support for `@deprecated`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Support for `@deprecated` field annotations. You can configure how
+  deprecations are handled via the `deprecated` argument in the `GraphQLQuery`
+  derive:
+
+  ```rust
+  #[derive(GraphQLQuery)]
+  #[graphql(
+      schema_path = "src/graphql/schema.json",
+      query_path = "src/graphql/queries/my_query.graphql",
+      deprecated = "warn"
+  )]
+  pub struct MyQuery;
+  ```
+
+  Valid values are:
+
+  - `allow`: the response struct fields are not marked as deprecated.
+  - `warn`: the response struct fields are marked as `#[deprecated]`.
+  - `deny`: The struct fields are not included in the response struct and
+    using them is a compile error.
+
+  The default is `warn`.
+
 ## [0.4.0] - 2018-08-23
 
 There are a number of breaking changes due to the new features, read the `Added` section attentively if you are upgrading.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A typed GraphQL client library for Rust.
 - Arbitrary derives on the generated responses
 - Arbitrary custom scalars
 - Supports multiple operations per query document
+- Supports setting GraphQL fields as deprecated and having the Rust compiler check
+  their use.
 
 ## Getting started
 
@@ -96,6 +98,30 @@ struct SearchQuery;
 ## Custom scalars
 
 The generated code will reference the scalar types as defined in the server schema. This means you have to provide matching rust types in the scope of the struct under derive. It can be as simple as declarations like `type Email = String;`. This gives you complete freedom on how to treat custom scalars, as long as they can be deserialized.
+
+## Deprecations
+
+The generated code has support for [`@deprecated`](http://facebook.github.io/graphql/June2018/#sec-Field-Deprecation)
+field annotations. You can configure how deprecations are handled via the `deprecated` argument in the `GraphQLQuery` derive:
+
+```rust
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema.json",
+    query_path = "src/graphql/queries/my_query.graphql",
+    deprecated = "warn"
+)]
+pub struct MyQuery;
+```
+
+Valid values are:
+
+- `allow`: the response struct fields are not marked as deprecated.
+- `warn`: the response struct fields are marked as `#[deprecated]`.
+- `deny`: The struct fields are not included in the response struct and
+  using them is a compile error.
+
+The default is `warn`.
 
 ## Query documents with multiple operations
 

--- a/graphql_query_derive/src/codegen.rs
+++ b/graphql_query_derive/src/codegen.rs
@@ -1,3 +1,4 @@
+use deprecation;
 use failure;
 use fragments::GqlFragment;
 use graphql_parser::query;
@@ -12,8 +13,9 @@ pub(crate) fn response_for_query(
     query: query::Document,
     selected_operation: String,
     additional_derives: Option<String>,
+    deprecation_strategy: deprecation::DeprecationStrategy,
 ) -> Result<TokenStream, failure::Error> {
-    let mut context = QueryContext::new(schema);
+    let mut context = QueryContext::new(schema, deprecation_strategy);
 
     if let Some(derives) = additional_derives {
         context.ingest_additional_derives(&derives).unwrap();

--- a/graphql_query_derive/src/constants.rs
+++ b/graphql_query_derive/src/constants.rs
@@ -1,3 +1,4 @@
+use deprecation::DeprecationStatus;
 use field_type::FieldType;
 use objects::GqlObjectField;
 use proc_macro2::{Ident, Span};
@@ -20,6 +21,7 @@ pub(crate) fn typename_field() -> GqlObjectField {
         /// Non-nullable, see spec:
         /// https://github.com/facebook/graphql/blob/master/spec/Section%204%20--%20Introspection.md
         type_: FieldType::Named(string_type()),
+        deprecation: DeprecationStatus::Current,
     }
 }
 

--- a/graphql_query_derive/src/deprecation.rs
+++ b/graphql_query_derive/src/deprecation.rs
@@ -1,0 +1,91 @@
+use attributes;
+use failure;
+use syn;
+
+static DEPRECATION_ERROR: &'static str = "deprecated must be one of 'allow', 'deny', or 'warn'";
+
+#[derive(Debug, PartialEq, Hash, Clone)]
+pub enum DeprecationStatus {
+    Current,
+    Deprecated(Option<String>),
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DeprecationStrategy {
+    Allow,
+    Deny,
+    Warn,
+}
+
+pub(crate) fn extract_deprecation_strategy(
+    ast: &syn::DeriveInput,
+) -> Result<DeprecationStrategy, failure::Error> {
+    match attributes::extract_attr(&ast, "deprecated")?
+        .to_lowercase()
+        .as_str()
+    {
+        "allow" => Ok(DeprecationStrategy::Allow),
+        "deny" => Ok(DeprecationStrategy::Deny),
+        "warn" => Ok(DeprecationStrategy::Warn),
+        _ => Err(format_err!("{}", DEPRECATION_ERROR))?,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_deprecation_strategy() {
+        let input = "
+        #[derive(GraphQLQuery)]
+        #[graphql(
+            schema_path = \"x\",
+            query_path = \"x\",
+            deprecated = \"warn\",
+        )]
+        struct MyQuery;
+        ";
+        let parsed = syn::parse_str(input).unwrap();
+        assert_eq!(
+            extract_deprecation_strategy(&parsed).unwrap(),
+            DeprecationStrategy::Warn
+        );
+    }
+
+    #[test]
+    fn test_deprecation_strategy_is_case_insensitive() {
+        let input = "
+        #[derive(GraphQLQuery)]
+        #[graphql(
+            schema_path = \"x\",
+            query_path = \"x\",
+            deprecated = \"DeNy\",
+        )]
+        struct MyQuery;
+        ";
+        let parsed = syn::parse_str(input).unwrap();
+        assert_eq!(
+            extract_deprecation_strategy(&parsed).unwrap(),
+            DeprecationStrategy::Deny
+        );
+    }
+
+    #[test]
+    fn test_invalid_deprecation_strategy() {
+        let input = "
+        #[derive(GraphQLQuery)]
+        #[graphql(
+            schema_path = \"x\",
+            query_path = \"x\",
+            deprecated = \"foo\",
+        )]
+        struct MyQuery;
+        ";
+        let parsed = syn::parse_str(input).unwrap();
+        match extract_deprecation_strategy(&parsed) {
+            Ok(_) => panic!("parsed unexpectedly"),
+            Err(e) => assert_eq!(&format!("{}", e), DEPRECATION_ERROR),
+        };
+    }
+}

--- a/graphql_query_derive/src/inputs.rs
+++ b/graphql_query_derive/src/inputs.rs
@@ -1,3 +1,4 @@
+use deprecation::DeprecationStatus;
 use failure;
 use graphql_parser;
 use heck::SnakeCase;
@@ -53,6 +54,7 @@ impl ::std::convert::From<graphql_parser::schema::InputObjectType> for GqlInput 
                         description: None,
                         name: field.name,
                         type_: field.value_type.into(),
+                        deprecation: DeprecationStatus::Current,
                     };
                     (name, field)
                 }).collect(),
@@ -80,6 +82,7 @@ impl ::std::convert::From<introspection_response::FullType> for GqlInput {
                             .type_
                             .expect("type on input object field")
                             .into(),
+                        deprecation: DeprecationStatus::Current,
                     };
                     (name, field)
                 }).collect(),
@@ -105,6 +108,7 @@ mod tests {
                         description: None,
                         name: "pawsCount".to_string(),
                         type_: FieldType::Named(float_type()),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ),
                 (
@@ -116,6 +120,7 @@ mod tests {
                             "Cat",
                             Span::call_site(),
                         )))),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ),
                 (
@@ -127,6 +132,7 @@ mod tests {
                             "CatRequirements",
                             Span::call_site(),
                         )))),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ),
             ].into_iter()

--- a/graphql_query_derive/src/query.rs
+++ b/graphql_query_derive/src/query.rs
@@ -1,3 +1,4 @@
+use deprecation::DeprecationStrategy;
 use failure;
 use fragments::GqlFragment;
 use operations::Operation;
@@ -13,16 +14,18 @@ pub(crate) struct QueryContext {
     pub fragments: BTreeMap<String, GqlFragment>,
     pub schema: Schema,
     pub selected_operation: Option<Operation>,
+    pub deprecation_strategy: DeprecationStrategy,
     response_derives: Vec<Ident>,
 }
 
 impl QueryContext {
     /// Create a QueryContext with the given Schema.
-    pub(crate) fn new(schema: Schema) -> QueryContext {
+    pub(crate) fn new(schema: Schema, deprecation_strategy: DeprecationStrategy) -> QueryContext {
         QueryContext {
             fragments: BTreeMap::new(),
             schema,
             selected_operation: None,
+            deprecation_strategy,
             response_derives: vec![Ident::new("Deserialize", Span::call_site())],
         }
     }
@@ -34,6 +37,7 @@ impl QueryContext {
             fragments: BTreeMap::new(),
             schema: Schema::new(),
             selected_operation: None,
+            deprecation_strategy: DeprecationStrategy::Allow,
             response_derives: vec![Ident::new("Deserialize", Span::call_site())],
         }
     }

--- a/graphql_query_derive/src/schema.rs
+++ b/graphql_query_derive/src/schema.rs
@@ -1,3 +1,4 @@
+use deprecation::DeprecationStatus;
 use enums::{EnumVariant, GqlEnum};
 use failure;
 use field_type::FieldType;
@@ -126,6 +127,7 @@ impl ::std::convert::From<graphql_parser::schema::Document> for Schema {
                                 description: f.description.as_ref().map(|s| s.to_owned()),
                                 name: f.name.clone(),
                                 type_: FieldType::from(f.field_type.clone()),
+                                deprecation: DeprecationStatus::Current,
                             }));
                         schema.interfaces.insert(interface.name, iface);
                     }
@@ -262,6 +264,7 @@ impl ::std::convert::From<::introspection_response::IntrospectionResponse> for S
                                 description: f.description,
                                 name: f.name.expect("field name"),
                                 type_: FieldType::from(f.type_.expect("field type")),
+                                deprecation: DeprecationStatus::Current,
                             }),
                     );
                     schema.interfaces.insert(name, iface);
@@ -302,16 +305,19 @@ mod tests {
                         description: None,
                         name: TYPENAME_FIELD.to_string(),
                         type_: FieldType::Named(string_type()),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "id".to_string(),
                         type_: FieldType::Named(Ident::new("ID", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "name".to_string(),
                         type_: FieldType::Named(Ident::new("String", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
@@ -322,11 +328,13 @@ mod tests {
                                 Span::call_site(),
                             )))),
                         )))),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "friendsConnection".to_string(),
                         type_: FieldType::Named(Ident::new("FriendsConnection", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
@@ -334,6 +342,7 @@ mod tests {
                         type_: FieldType::Vector(Box::new(FieldType::Optional(Box::new(
                             FieldType::Named(Ident::new("Episode", Span::call_site())),
                         )))),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
@@ -342,6 +351,7 @@ mod tests {
                             "String",
                             Span::call_site(),
                         )))),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ],
             })

--- a/graphql_query_derive/src/unions.rs
+++ b/graphql_query_derive/src/unions.rs
@@ -66,7 +66,7 @@ pub(crate) fn union_variants(
                             query_context.maybe_expand_field(
                                 &frag.on,
                                 &frag.fields,
-                                &new_prefix
+                                &new_prefix,
                             )
                         });
                         // nested unions, is that even a thing?
@@ -140,6 +140,7 @@ impl GqlUnion {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use deprecation::DeprecationStatus;
     use field_type::FieldType;
     use objects::{GqlObject, GqlObjectField};
     use selection::*;
@@ -180,16 +181,20 @@ mod tests {
                         description: None,
                         name: "firstName".to_string(),
                         type_: FieldType::Named(Ident::new("String", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "lastName".to_string(),
                         type_: FieldType::Named(Ident::new("String", Span::call_site())),
+
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "createdAt".to_string(),
                         type_: FieldType::Named(Ident::new("Date", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ],
             },
@@ -205,11 +210,13 @@ mod tests {
                         description: None,
                         name: "title".to_string(),
                         type_: FieldType::Named(Ident::new("String", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "created_at".to_string(),
                         type_: FieldType::Named(Ident::new("Date", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ],
             },
@@ -269,21 +276,25 @@ mod tests {
                         description: None,
                         name: "__typename".to_string(),
                         type_: FieldType::Named(string_type()),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "firstName".to_string(),
                         type_: FieldType::Named(string_type()),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "lastName".to_string(),
                         type_: FieldType::Named(string_type()),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "createdAt".to_string(),
                         type_: FieldType::Named(Ident::new("Date", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ],
             },
@@ -299,16 +310,19 @@ mod tests {
                         description: None,
                         name: "__typename".to_string(),
                         type_: FieldType::Named(string_type()),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "title".to_string(),
                         type_: FieldType::Named(Ident::new("String", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                     GqlObjectField {
                         description: None,
                         name: "createdAt".to_string(),
                         type_: FieldType::Named(Ident::new("Date", Span::call_site())),
+                        deprecation: DeprecationStatus::Current,
                     },
                 ],
             },

--- a/tests/deprecation.rs
+++ b/tests/deprecation.rs
@@ -1,0 +1,76 @@
+#[macro_use]
+extern crate graphql_client;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "tests/deprecation/schema.graphql",
+    query_path = "tests/deprecation/query.graphql",
+    deprecated = "allow",
+)]
+#[allow(unused_variables, dead_code)]
+struct AllowDeprecation;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "tests/deprecation/schema.graphql",
+    query_path = "tests/deprecation/query.graphql",
+    deprecated = "deny",
+)]
+#[allow(unused_variables, dead_code)]
+struct DenyDeprecation;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "tests/deprecation/schema.graphql",
+    query_path = "tests/deprecation/query.graphql",
+    deprecated = "warn",
+)]
+#[allow(unused_variables, dead_code)]
+struct WarnDeprecation;
+
+#[test]
+fn deprecation_allow() {
+    // Make any deprecations be a compile error.
+    // Under `allow`, even deprecated fields aren't marked as such.
+    // Thus this is checking that the deprecated fields exist and aren't marked
+    // as deprecated.
+    #![deny(deprecated)]
+    let _ = allow_deprecation::ResponseData {
+        current_user: Some(allow_deprecation::RustTestCurrentUser {
+            id: Some("abcd".to_owned()),
+            name: Some("Angela Merkel".to_owned()),
+            deprecated_with_reason: Some("foo".to_owned()),
+            deprecated_no_reason: Some("bar".to_owned()),
+        }),
+    };
+}
+
+#[test]
+fn deprecation_deny() {
+    let _ = deny_deprecation::ResponseData {
+        current_user: Some(deny_deprecation::RustTestCurrentUser {
+            id: Some("abcd".to_owned()),
+            name: Some("Angela Merkel".to_owned()),
+            // Notice the deprecated fields are not included here.
+            // If they were generated, not using them would be a compile error.
+            // Thus this is checking that the depreacted fields are not
+            // generated under the `deny` scheme.
+        }),
+    };
+}
+
+#[test]
+fn deprecation_warn() {
+    #![allow(deprecated)]
+    let _ = warn_deprecation::ResponseData {
+        current_user: Some(warn_deprecation::RustTestCurrentUser {
+            id: Some("abcd".to_owned()),
+            name: Some("Angela Merkel".to_owned()),
+            deprecated_with_reason: Some("foo".to_owned()),
+            deprecated_no_reason: Some("bar".to_owned()),
+        }),
+    };
+}

--- a/tests/deprecation/query.graphql
+++ b/tests/deprecation/query.graphql
@@ -1,0 +1,8 @@
+query Test {
+  currentUser {
+    name
+    id
+    deprecatedWithReason
+    deprecatedNoReason
+  }
+}

--- a/tests/deprecation/schema.graphql
+++ b/tests/deprecation/schema.graphql
@@ -1,0 +1,14 @@
+schema {
+  query: TestQuery
+}
+
+type TestQuery {
+  currentUser: TestUser
+}
+
+type TestUser {
+  name: String
+  id: ID
+  deprecatedWithReason: String @deprecated(reason: "Because")
+  deprecatedNoReason: String @deprecated
+}


### PR DESCRIPTION
Fixes https://github.com/tomhoule/graphql-client/issues/62.