### PR TITLE
graphql_query_derive: support aliases in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Improved some codegen error messages, giving more context. Thank @mathstuf!
 
+- Aliases in queries are now supported.
+
 ### Fixed
 
 - Handle all Rust keywords as field names in codegen by appending `_` to the generated names, so a field called `type` in a GraphQL query will become a `type_` field in the generated struct. Thanks to @scrogson!

--- a/graphql_query_derive/src/selection.rs
+++ b/graphql_query_derive/src/selection.rs
@@ -3,6 +3,7 @@ use graphql_parser::query::SelectionSet;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SelectionField {
+    pub alias: Option<String>,
     pub name: String,
     pub fields: Selection,
 }
@@ -54,6 +55,7 @@ impl<'a> ::std::convert::From<&'a SelectionSet> for Selection {
         for item in &selection_set.items {
             let converted = match item {
                 Selection::Field(f) => SelectionItem::Field(SelectionField {
+                    alias: f.alias.as_ref().map(|alias| alias.to_string()),
                     name: f.name.to_string(),
                     fields: (&f.selection_set).into(),
                 }),
@@ -99,6 +101,7 @@ mod tests {
                 rating
             }
             pawsCount
+            aliased: sillyName
           }
         }
         "##;
@@ -123,13 +126,16 @@ mod tests {
         assert_eq!(
             selection,
             Selection(vec![SelectionItem::Field(SelectionField {
+                alias: None,
                 name: "animal".to_string(),
                 fields: Selection(vec![
                     SelectionItem::Field(SelectionField {
+                        alias: None,
                         name: "isCat".to_string(),
                         fields: Selection(Vec::new()),
                     }),
                     SelectionItem::Field(SelectionField {
+                        alias: None,
                         name: "isHorse".to_string(),
                         fields: Selection(Vec::new()),
                     }),
@@ -137,18 +143,26 @@ mod tests {
                         fragment_name: "Timestamps".to_string(),
                     }),
                     SelectionItem::Field(SelectionField {
+                        alias: None,
                         name: "barks".to_string(),
                         fields: Selection(Vec::new()),
                     }),
                     SelectionItem::InlineFragment(SelectionInlineFragment {
                         on: "Dog".to_string(),
                         fields: Selection(vec![SelectionItem::Field(SelectionField {
+                            alias: None,
                             name: "rating".to_string(),
                             fields: Selection(Vec::new()),
                         })]),
                     }),
                     SelectionItem::Field(SelectionField {
+                        alias: None,
                         name: "pawsCount".to_string(),
+                        fields: Selection(Vec::new()),
+                    }),
+                    SelectionItem::Field(SelectionField {
+                        alias: Some("aliased".to_string()),
+                        name: "sillyName".to_string(),
                         fields: Selection(Vec::new()),
                     }),
                 ]),

--- a/graphql_query_derive/src/shared.rs
+++ b/graphql_query_derive/src/shared.rs
@@ -72,16 +72,19 @@ pub(crate) fn field_impls_for_selection(
         .iter()
         .map(|selected| {
             if let SelectionItem::Field(selected) = selected {
+                let name = &selected.name;
+                let alias = selected.alias.as_ref().unwrap_or(name);
+
                 let ty = fields
                     .iter()
-                    .find(|f| f.name == selected.name)
-                    .ok_or_else(|| format_err!("could not find field `{}`", selected.name))?
+                    .find(|f| &f.name == name)
+                    .ok_or_else(|| format_err!("could not find field `{}`", name))?
                     .type_
                     .inner_name_string();
                 let prefix = format!(
                     "{}{}",
                     prefix.to_camel_case(),
-                    selected.name.to_camel_case()
+                    alias.to_camel_case()
                 );
                 context.maybe_expand_field(&ty, &selected.fields, &prefix)
             } else {
@@ -103,6 +106,7 @@ pub(crate) fn response_fields_for_selection(
         .map(|item| match item {
             SelectionItem::Field(f) => {
                 let name = &f.name;
+                let alias = f.alias.as_ref().unwrap_or(name);
 
                 let schema_field = &schema_fields
                     .iter()
@@ -110,11 +114,11 @@ pub(crate) fn response_fields_for_selection(
                     .ok_or_else(|| format_err!("Could not find field: {}", name.as_str()))?;
                 let ty = schema_field.type_.to_rust(
                     context,
-                    &format!("{}{}", prefix.to_camel_case(), name.to_camel_case()),
+                    &format!("{}{}", prefix.to_camel_case(), alias.to_camel_case()),
                 );
 
                 Ok(render_object_field(
-                    name,
+                    alias,
                     &ty,
                     schema_field.description.as_ref().map(|s| s.as_str()),
                     &schema_field.deprecation,

--- a/graphql_query_derive/src/unions.rs
+++ b/graphql_query_derive/src/unions.rs
@@ -151,6 +151,7 @@ mod tests {
             SelectionItem::InlineFragment(SelectionInlineFragment {
                 on: "User".to_string(),
                 fields: Selection(vec![SelectionItem::Field(SelectionField {
+                    alias: None,
                     name: "firstName".to_string(),
                     fields: Selection(vec![]),
                 })]),
@@ -158,6 +159,7 @@ mod tests {
             SelectionItem::InlineFragment(SelectionInlineFragment {
                 on: "Organization".to_string(),
                 fields: Selection(vec![SelectionItem::Field(SelectionField {
+                    alias: None,
                     name: "title".to_string(),
                     fields: Selection(vec![]),
                 })]),
@@ -236,12 +238,14 @@ mod tests {
     fn union_response_for_selection_works() {
         let fields = vec![
             SelectionItem::Field(SelectionField {
+                alias: None,
                 name: "__typename".to_string(),
                 fields: Selection(vec![]),
             }),
             SelectionItem::InlineFragment(SelectionInlineFragment {
                 on: "User".to_string(),
                 fields: Selection(vec![SelectionItem::Field(SelectionField {
+                    alias: None,
                     name: "firstName".to_string(),
                     fields: Selection(vec![]),
                 })]),
@@ -249,6 +253,7 @@ mod tests {
             SelectionItem::InlineFragment(SelectionInlineFragment {
                 on: "Organization".to_string(),
                 fields: Selection(vec![SelectionItem::Field(SelectionField {
+                    alias: None,
                     name: "title".to_string(),
                     fields: Selection(vec![]),
                 })]),

--- a/tests/alias.rs
+++ b/tests/alias.rs
@@ -1,0 +1,41 @@
+#[macro_use]
+extern crate graphql_client;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "tests/alias/query.graphql",
+    schema_path = "tests/alias/schema.graphql"
+)]
+#[allow(dead_code)]
+struct AliasQuery;
+
+#[test]
+fn alias() {
+    let valid_response = json!({
+        "alias": "127.0.1.2",
+        "outer_alias": {
+            "inner_alias": "inner value",
+        },
+    });
+
+    let _type_name_test = alias_query::RustAliasQueryOuterAlias {
+        inner_alias: None,
+    };
+
+    let valid_alias =
+        serde_json::from_value::<alias_query::ResponseData>(valid_response).unwrap();
+
+    assert_eq!(
+        valid_alias.alias.unwrap(),
+        "127.0.1.2"
+    );
+    assert_eq!(
+        valid_alias.outer_alias.unwrap().inner_alias.unwrap(),
+        "inner value"
+    );
+}

--- a/tests/alias/query.graphql
+++ b/tests/alias/query.graphql
@@ -1,0 +1,6 @@
+query AliasQuery {
+  alias: address
+  outer_alias: nested {
+    inner_alias: inner
+  }
+}

--- a/tests/alias/schema.graphql
+++ b/tests/alias/schema.graphql
@@ -1,0 +1,12 @@
+schema {
+  query: QueryRoot
+}
+
+type QueryNest {
+  inner: String
+}
+
+type QueryRoot {
+  address: String
+  nested: QueryNest
+}


### PR DESCRIPTION
When querying a very abstract API (e.g., "find me database entry X"),
the name of fields may be better named in the query side.