### PR TITLE
gitignore: ignore `target` as a symlink as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-target/
+/target
 node_modules/
 **/*.rs.bk
 Cargo.lock


### PR DESCRIPTION
---
When `target` is a symlink, it is not ignored with a trailing slash. Instead, just ignore `target` at the top-level.