### PR TITLE
graphql_query_derive: support deriving for input variables as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Aliases in queries are now supported.
 
+- The traits in `response_derives` are now used for input types as well.
+
 ### Fixed
 
 - Handle all Rust keywords as field names in codegen by appending `_` to the generated names, so a field called `type` in a GraphQL query will become a `type_` field in the generated struct. Thanks to @scrogson!

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 
 [dependencies]
 failure = "0.1"
+itertools = "0.7"
 lazy_static = "1.0"
 quote = "^0.6"
 syn = "0.14"

--- a/graphql_query_derive/src/inputs.rs
+++ b/graphql_query_derive/src/inputs.rs
@@ -30,9 +30,10 @@ impl GqlInput {
 
             quote!(#rename pub #name: #ty)
         });
+        let variables_derives = context.variables_derives();
 
         Ok(quote! {
-            #[derive(Debug, Serialize)]
+            #variables_derives
             pub struct #name {
                 #(#fields,)*
             }
@@ -134,7 +135,7 @@ mod tests {
         };
 
         let expected: String = vec![
-            "# [ derive ( Debug , Serialize ) ] ",
+            "# [ derive ( Serialize , Clone ) ] ",
             "pub struct Cat { ",
             "pub offsprings : Vec < Cat > , ",
             "# [ serde ( rename = \"pawsCount\" ) ] ",
@@ -146,6 +147,7 @@ mod tests {
 
         let mut context = QueryContext::new_empty();
         context.schema.inputs.insert(cat.name.clone(), cat);
+        context.ingest_additional_derives("Clone").unwrap();
 
         assert_eq!(
             format!(

--- a/graphql_query_derive/src/lib.rs
+++ b/graphql_query_derive/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate failure;
 extern crate graphql_parser;
 extern crate heck;
+extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
 extern crate proc_macro;

--- a/graphql_query_derive/src/operations.rs
+++ b/graphql_query_derive/src/operations.rs
@@ -42,8 +42,10 @@ impl Operation {
     pub(crate) fn expand_variables(&self, context: &QueryContext) -> TokenStream {
         let variables = &self.variables;
 
+        let variables_derives = context.variables_derives();
+
         if variables.is_empty() {
-            return quote!(#[derive(Serialize)]
+            return quote!(#variables_derives
             pub struct Variables;);
         }
 
@@ -62,7 +64,7 @@ impl Operation {
             .map(|variable| variable.generate_default_value_constructor(context));
 
         quote! {
-            #[derive(Serialize)]
+            #variables_derives
             pub struct Variables {
                 #(#fields,)*
             }


### PR DESCRIPTION
This just hijacks the `reponse_derives` attribute right now since it
controls derives for generated data structures and `Variables` shares
much of that.

Fixes #103.

---
Should `response_derives` be renamed to `extra_derives` since it now applies to every generated type?