### PR TITLE
GraphQLQueryBody: send `operationName` as well

### DIFF
--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -78,6 +78,7 @@ fn introspect_schema(
     let request_body: graphql_client::GraphQLQueryBody<()> = graphql_client::GraphQLQueryBody {
         variables: (),
         query: introspection_query::QUERY,
+        operation_name: introspection_query::OPERATION_NAME,
     };
 
     let headers = set_headers(authorization);

--- a/graphql_client_codegen/src/lib.rs
+++ b/graphql_client_codegen/src/lib.rs
@@ -122,7 +122,8 @@ pub fn generate_module_token_stream(
         }
     };
 
-    let module_name = Ident::new(&input.ident.to_string().to_snake_case(), Span::call_site());
+    let operation_string = input.ident.to_string();
+    let module_name = Ident::new(&operation_string.to_snake_case(), Span::call_site());
     let struct_name = &input.ident;
     let schema_output = codegen::response_for_query(
         schema,
@@ -141,6 +142,7 @@ pub fn generate_module_token_stream(
             use serde;
 
             pub const QUERY: &'static str = #query_string;
+            pub const OPERATION_NAME: &'static str = #operation_string;
 
             #schema_output
         }
@@ -153,6 +155,7 @@ pub fn generate_module_token_stream(
                 ::graphql_client::GraphQLQueryBody {
                     variables,
                     query: #module_name::QUERY,
+                    operation_name: #module_name::OPERATION_NAME,
                 }
 
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ use std::collections::HashMap;
 ///     };
 ///
 ///     let expected_body = json!({
+///         "operationName": star_wars_query::OPERATION_NAME,
 ///         "query": star_wars_query::QUERY,
 ///         "variables": {
 ///             "episodeForHero": "NEWHOPE"
@@ -84,6 +85,9 @@ where
     pub variables: Variables,
     /// The GraphQL query, as a string.
     pub query: &'static str,
+    /// The GraphQL operation name, as a string.
+    #[serde(rename = "operationName")]
+    pub operation_name: &'static str,
 }
 
 /// Represents a location inside a query string. Used in errors. See [`GraphQLError`].


### PR DESCRIPTION
When using a single query file for multiple actual queries, the server
needs to know which one we're actually asking for.