### PR TITLE
Upgrade reqwest to ^0.9.0

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -9,7 +9,7 @@ graphql_client = { path = "../.." }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest = "*"
+reqwest = "^0.9.0"
 prettytable-rs = "0.7.0"
 structopt = "0.2.10"
 dotenv = "0.13.0"

--- a/examples/github/src/main.rs
+++ b/examples/github/src/main.rs
@@ -69,10 +69,8 @@ fn main() -> Result<(), failure::Error> {
 
     let mut res = client
         .post("https://api.github.com/graphql")
-        .header(reqwest::header::Authorization(format!(
-            "bearer {}",
-            config.github_api_token
-        ))).json(&q)
+        .bearer_auth(config.github_api_token)
+        .json(&q)
         .send()?;
 
     let response_body: GraphQLResponse<query1::ResponseData> = res.json()?;

--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 failure = "0.1"
-reqwest = "0.8"
+reqwest = "^0.9.0"
 graphql_client = { version = "0.4.0", path = ".." }
 structopt = "0.2"
 serde = "1.0"


### PR DESCRIPTION
related #121

reqwest v0.8.x don't correspond to openssl 1.1.1.
So we should upgrade reqwest.
There are [some breaking changes](https://github.com/seanmonstar/reqwest/blob/master/CHANGELOG.md#breaking-changes).

refer to: https://docs.rs/reqwest/0.9.0/reqwest/struct.RequestBuilder.html#method.headers